### PR TITLE
Add Node.js Express server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This repository contains the static landing page for **NoLimit**. The project no
 
 ## Viewing the Site
 
-To view the site locally, clone this repository and open `index.html` or any of the other pages (`blog.html`, `videos.html`, `gallery.html`) in your favorite browser.
+To view the site locally, you can either open the static HTML files directly or run the included Node.js server.
+
+### Opening the static files
+
+Clone this repository and open `index.html` or any of the other pages (`blog.html`, `videos.html`, `gallery.html`) in your favorite browser.
 
 ```
 # Example
@@ -12,6 +16,17 @@ $ git clone <repo-url>
 $ cd Sampraw.com
 $ xdg-open index.html  # or open index.html on your system
 ```
+
+### Running the Express server
+
+If you have Node.js installed, you can start a local server using Express to serve the pages:
+
+```
+$ npm install
+$ npm start
+```
+
+The site will be available at `http://localhost:3000` by default.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nolemit-landing-page",
+  "version": "1.0.0",
+  "description": "NoLimit landing page with Express server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname)));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server started at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a simple Express server for serving the site
- ignore node dependencies
- document how to run the server with Node

## Testing
- `npm install --silent` *(fails: network access blocked)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684d1ad39f2c8326880636a45ce3ce42